### PR TITLE
Direct app CTAs, Loops CORS fix, and legal page updates

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -40,4 +40,7 @@
   body {
     @apply bg-background text-foreground;
   }
+  .prose hr {
+    @apply my-8;
+  }
 }

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,69 +1,197 @@
+import Link from "next/link"
+
 export default function PrivacyPage() {
-    return (
-        <main className="container mx-auto px-4 py-12 max-w-3xl">
-            <h1 className="text-4xl font-bold mb-8">Privacy Policy</h1>
-            <div className="prose prose-blue max-w-none">
-                <p>Inbox Athletics ("we", "us", or "our") respects your privacy. This Privacy Policy explains how we
-                    collect, use, and protect your information.</p>
+  return (
+    <main className="container mx-auto px-4 py-12 max-w-3xl">
+      <Link href="/" className="inline-block mb-8">
+        <img src="/inbox-athletics-logo-without-tagline.svg" alt="Inbox Athletics" className="h-8 w-auto" />
+      </Link>
+      <h1 className="text-4xl font-bold mb-2">Privacy Policy</h1>
+      <p className="mb-8">
+        <strong>Inbox Athletics LLC</strong> (&ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) is committed to being transparent about how we handle your data. This Privacy Policy explains what information we collect, how we use it, who we share it with, and what rights you have — including specific disclosures required for our use of Google account data.
+      </p>
+      <p className="mb-8"><strong>Effective Date:</strong> February 18, 2026</p>
+      <div className="prose prose-blue max-w-none">
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">1. Information We Collect</h2>
-                <ul className="list-disc list-inside">
-                    <li><strong>Personal Information:</strong> Name, email address, phone number, school, graduation
-                        year, sport, etc.
-                    </li>
-                    <li><strong>Usage Data:</strong> How you interact with our platform (e.g., page visits, features
-                        used).
-                    </li>
-                    <li><strong>Connected Account Data:</strong> If you connect your email or calendar, we may access
-                        relevant metadata and message content strictly for functionality (e.g., syncing communication).
-                    </li>
-                </ul>
+        <h2 className="text-xl font-semibold mt-6">1. Who We Are and Who This Policy Covers</h2>
+        <p>Inbox Athletics LLC operates the Inbox Athletics platform, a recruiting communication tool designed for high school student-athletes (ages 13–18) and their families. Because many of our users are minors, we take data privacy seriously and apply heightened care to how we collect, use, and protect personal information.</p>
 
-                <h2 className="text-xl font-semibold mt-6">2. How We Use Your Information</h2>
-                <ul className="list-disc list-inside">
-                    <li>To provide and improve the Service.</li>
-                    <li>To personalize your experience.</li>
-                    <li>To facilitate communication between athletes and coaches.</li>
-                    <li>To send service notifications and updates.</li>
-                    <li>For analytics and feature development.</li>
-                </ul>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">3. Sharing of Information</h2>
-                <ul className="list-disc list-inside">
-                    <li>We do not sell your personal information.</li>
-                    <li>We may share data with trusted service providers who help us operate the Service (e.g., email
-                        sync providers, hosting services).
-                    </li>
-                    <li>We may disclose information if required by law or to protect rights, safety, or property.</li>
-                </ul>
+        <h2 className="text-xl font-semibold mt-6">2. Information We Collect</h2>
 
-                <h2 className="text-xl font-semibold mt-6">4. Data Security</h2>
-                <p>We implement industry-standard security measures to protect your data. However, no method of
-                    transmission over the internet is 100% secure.</p>
+        <h3 className="text-lg font-semibold mt-4">a. Information You Provide Directly</h3>
+        <ul className="list-disc list-inside">
+          <li>Name, email address, phone number, graduation year, school, sport, and position</li>
+          <li>Profile information such as GPA, recruiting status, and athletic highlights</li>
+          <li>Coach contact information and notes you enter manually</li>
+          <li>Messages and content you compose within the platform</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">5. Your Choices</h2>
-                <ul className="list-disc list-inside">
-                    <li>You can access and update your personal information through your account settings.</li>
-                    <li>You can disconnect third-party integrations at any time.</li>
-                    <li>You may request deletion of your account and associated data.</li>
-                </ul>
+        <h3 className="text-lg font-semibold mt-4">b. Information We Collect Automatically</h3>
+        <ul className="list-disc list-inside">
+          <li>Usage data: how you interact with the platform (pages visited, features used, actions taken)</li>
+          <li>Device and browser information</li>
+          <li>IP address and approximate location (city/region level)</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">6. Children's Privacy</h2>
-                <p>We do not knowingly collect personal information from children under 13. Users under 18 must have
-                    parental consent.</p>
+        <h3 className="text-lg font-semibold mt-4">c. Google Account Data (Gmail Integration)</h3>
+        <p>When you connect your Google account, we request access to the following Google OAuth scopes:</p>
+        <table className="w-full text-left border-collapse my-4">
+          <thead>
+            <tr>
+              <th className="border-b border-border py-2 pr-4 font-semibold">Scope</th>
+              <th className="border-b border-border py-2 font-semibold">What It Enables</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="border-b border-border py-2 pr-4"><code>gmail.readonly</code></td>
+              <td className="border-b border-border py-2">Reading your recruiting-related emails to populate your inbox and relationship history</td>
+            </tr>
+            <tr>
+              <td className="border-b border-border py-2 pr-4"><code>gmail.send</code></td>
+              <td className="border-b border-border py-2">Sending emails to coaches on your behalf from within the platform</td>
+            </tr>
+            <tr>
+              <td className="border-b border-border py-2 pr-4"><code>gmail.compose</code></td>
+              <td className="border-b border-border py-2">Creating and pre-filling draft emails using AI-assisted suggestions</td>
+            </tr>
+            <tr>
+              <td className="border-b border-border py-2 pr-4"><code>userinfo.email</code> / <code>profile</code></td>
+              <td className="border-b border-border py-2">Identifying your Google account to connect it to your Inbox Athletics profile</td>
+            </tr>
+          </tbody>
+        </table>
+        <p><strong>What we access from Gmail:</strong> We access email body content, subject lines, sender and recipient information, and message timestamps — but only for emails relevant to your recruiting communications. We use this data to power your recruiting inbox, assess your coach relationships, and help you draft outreach.</p>
+        <p><strong>What we store:</strong> We store full email body content in our database while your account is active. This is necessary to provide relationship health assessments and AI-assisted content drafting across sessions.</p>
 
-                <h2 className="text-xl font-semibold mt-6">7. Data Retention</h2>
-                <p>We retain your data as long as necessary to provide the Service or comply with legal obligations.</p>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">8. Changes to This Policy</h2>
-                <p>We may revise this Privacy Policy. Material changes will be communicated via the platform or
-                    email.</p>
+        <h2 className="text-xl font-semibold mt-6">3. How We Use Your Information</h2>
+        <p>We use the information we collect solely to operate and improve the Inbox Athletics platform. Specifically:</p>
+        <ul className="list-disc list-inside">
+          <li>To display and organize your recruiting communications in one place</li>
+          <li>To analyze your coach relationships and surface recruiting insights</li>
+          <li>To assist you in drafting emails, subject lines, and follow-up messages using AI</li>
+          <li>To extract coach contact information from your email history and populate your recruiting network</li>
+          <li>To send you service notifications and platform updates</li>
+          <li>To understand how features are being used so we can improve the product (using anonymized, aggregated behavioral data)</li>
+        </ul>
+        <p><strong>We do not use your data to serve advertisements.</strong> We do not build advertising profiles. We do not sell your personal information or your Google account data to any third party.</p>
 
-                <h2 className="text-xl font-semibold mt-6">9. Contact</h2>
-                <p>For questions about this Privacy Policy, contact: <a className="text-blue-600 underline"
-                                                                        href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a>
-                </p>
-            </div>
-        </main>
-    )
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">4. Google API Data — Limited Use Disclosure</h2>
+        <p>Our use of data obtained through Google APIs complies with the <a className="text-blue-600 underline" href="https://developers.google.com/terms/api-services-user-data-policy">Google API Services User Data Policy</a>, including the Limited Use requirements.</p>
+        <p>Specifically:</p>
+        <ul className="list-disc list-inside">
+          <li>We use Google account data <strong>only</strong> to provide the features described in this Privacy Policy — organizing recruiting communications, assessing coach relationships, and assisting with email drafting.</li>
+          <li>We do <strong>not</strong> use Google account data to develop, improve, or train generalized AI or machine learning models.</li>
+          <li>We do <strong>not</strong> transfer Google account data to third parties except as necessary to provide the features you have requested, as described in Section 6 below.</li>
+          <li>We do <strong>not</strong> allow humans to read your Gmail content except: (a) with your explicit permission; (b) as necessary for security or abuse investigation; or (c) as required by law.</li>
+          <li>We do <strong>not</strong> use Gmail data for any purpose that is not directly related to your use of Inbox Athletics.</li>
+        </ul>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">5. AI-Powered Features and Data Processing</h2>
+        <p>Inbox Athletics uses artificial intelligence to power several core features, including email drafting assistance, subject line suggestions, coach contact extraction, and relationship analysis. To provide these features, we send relevant data to third-party AI providers.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Anthropic (Claude)</h3>
+        <p>We use Anthropic&apos;s Claude API to power features including email drafting, subject line generation, and coach contact extraction from email history. This may involve sending email body content, subject lines, and sender/recipient metadata to Anthropic&apos;s API for processing. Anthropic processes this data on our behalf and is contractually prohibited from using it for their own purposes. For more information, see <a className="text-blue-600 underline" href="https://www.anthropic.com/privacy">Anthropic&apos;s Privacy Policy</a>.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Google (Gemini)</h3>
+        <p>We use Google&apos;s Gemini API (Gemini 2.5 Flash) to power high-volume analytical features including message classification, tone analysis, intent parsing, and thread summarization. These features analyze your recruiting communications to help organize your inbox and surface insights about your coach relationships. This may involve sending email body content, subject lines, and sender/recipient metadata to Google&apos;s Gemini API for processing. Google processes this data on our behalf as a service provider. For more information, see <a className="text-blue-600 underline" href="https://policies.google.com/privacy">Google&apos;s Privacy Policy</a>.</p>
+
+        <p>Data sent to AI providers is used only to generate responses for your specific request. It is not used to train AI models on your personal information.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">6. How We Share Your Information</h2>
+        <p>We do not sell your personal information. We share data only in the following limited circumstances:</p>
+        <ul className="list-disc list-inside">
+          <li><strong>AI Processing Partners:</strong> As described in Section 5, we share relevant email and message content with Anthropic and Google to power AI features. These providers act as data processors on our behalf.</li>
+          <li><strong>Infrastructure and Hosting Providers:</strong> We use third-party services for hosting, database management, and authentication (including Auth0 for login). These providers access data only as necessary to perform services for us.</li>
+          <li><strong>Analytics:</strong> We use PostHog for product analytics. PostHog receives anonymized behavioral and UI event data only — it does not receive email content, coach data, or any personally identifiable recruiting information.</li>
+          <li><strong>Legal Requirements:</strong> We may disclose information if required by law, court order, or to protect the rights, safety, or property of Inbox Athletics, our users, or the public.</li>
+          <li><strong>Business Transfers:</strong> In the event of a merger, acquisition, or sale of assets, your data may be transferred. We will notify you before your data becomes subject to a different privacy policy.</li>
+        </ul>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">7. Data Retention</h2>
+        <p><strong>While your account is active:</strong> We retain your profile information, coach contacts, notes, and email content for as long as your account is active and in good standing.</p>
+        <p><strong>After disconnecting your Google account:</strong> If you disconnect your Google account but keep your Inbox Athletics account, we will delete your cached email body content within <strong>30 days</strong> of disconnection. Your coach contacts, notes, profile, and other non-email data will remain in your account unless you delete it manually.</p>
+        <p><strong>After account deletion:</strong> When you delete your Inbox Athletics account, we delete your personal data within <strong>30 days</strong>, except where we are required to retain certain records for legal or compliance purposes (e.g., billing records).</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">8. Disconnecting Google Account Access</h2>
+        <p>You can disconnect your Google account from Inbox Athletics at any time through your account settings, or by revoking access directly through your <a className="text-blue-600 underline" href="https://myaccount.google.com/permissions">Google Account permissions page</a>. Revoking access through Google will immediately stop our ability to access your Gmail data going forward. Cached email content will be purged within 30 days as described in Section 7.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">9. Data Security</h2>
+        <p>We take the security of your data seriously, particularly given that we handle email content and communications with college coaches. Our security measures include:</p>
+        <ul className="list-disc list-inside">
+          <li>All data transmitted between your device and our servers is encrypted using TLS (Transport Layer Security)</li>
+          <li>Email content and personal data stored in our database is encrypted at rest</li>
+          <li>Google OAuth tokens are stored securely and never in plaintext</li>
+          <li>Access to production data is limited to authorized personnel only</li>
+          <li>We conduct periodic reviews of our security practices</li>
+        </ul>
+        <p>No method of data transmission or storage is 100% secure. If you believe your account has been compromised, please contact us immediately at <a className="text-blue-600 underline" href="mailto:security@inboxathletics.com">security@inboxathletics.com</a>.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">10. Children&apos;s Privacy and Parental Consent</h2>
+        <p>Inbox Athletics is designed for student-athletes ages 13 and older. We do not knowingly collect personal information from children under 13. If we learn that we have collected data from a child under 13 without verifiable parental consent, we will delete that information promptly.</p>
+        <p><strong>Users ages 13–17:</strong> Because many of our users are minors, we notify parents and guardians at the time of account creation. When a user under 18 signs up, we send an informational email to the parent or guardian email address provided at signup. That email explains what Inbox Athletics is, what data we collect (including name, athletic profile, and email communications with college coaches), how it is used, and the rights parents have to review, delete, or stop further collection of their child&apos;s information.</p>
+        <p>Parents and guardians may exercise the following rights at any time by contacting us at <a className="text-blue-600 underline" href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a>:</p>
+        <ul className="list-disc list-inside">
+          <li>Review the personal information we have collected from their child</li>
+          <li>Request deletion of their child&apos;s personal information</li>
+          <li>Refuse to allow any further collection or use of their child&apos;s information</li>
+        </ul>
+        <p>We do not use data from users under 18 for advertising, profiling, or any purpose beyond providing the recruiting platform features described in this policy.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">11. Your Rights and Choices</h2>
+        <p>Regardless of where you live, you have the following rights with respect to your personal data:</p>
+        <ul className="list-disc list-inside">
+          <li><strong>Access:</strong> You can view your profile information and coach data through your account settings.</li>
+          <li><strong>Correction:</strong> You can update your personal information at any time through account settings.</li>
+          <li><strong>Deletion:</strong> You can request deletion of your account and associated data by contacting us at <a className="text-blue-600 underline" href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a> or through account settings.</li>
+          <li><strong>Data Export:</strong> You can request an export of your coach contacts, notes, and communication history before closing your account.</li>
+          <li><strong>Disconnect Google:</strong> You can revoke Gmail access at any time without deleting your account (see Section 8).</li>
+          <li><strong>Opt Out of Promotional Communications:</strong> You can opt out of non-essential emails using the unsubscribe link in any promotional message.</li>
+        </ul>
+        <p><strong>California Residents (CCPA):</strong> You have the right to know what personal information we collect, request deletion, and opt out of the sale of personal information (we do not sell personal information). To exercise these rights, contact <a className="text-blue-600 underline" href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a>.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">12. Third-Party Links and Services</h2>
+        <p>The platform may contain links to third-party websites or resources (e.g., college athletic department pages). We are not responsible for the privacy practices of those sites and encourage you to review their policies independently.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">13. Changes to This Policy</h2>
+        <p>We may update this Privacy Policy from time to time. When we make material changes — particularly changes affecting how we use Google account data or AI processing — we will notify you via email and/or a prominent notice within the platform at least 14 days before the changes take effect. Your continued use of the platform after that date constitutes acceptance of the updated policy.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">14. Contact Us</h2>
+        <p>If you have questions, concerns, or requests related to this Privacy Policy, please contact us:</p>
+        <p>
+          <strong>Inbox Athletics LLC</strong><br />
+          Email: <a className="text-blue-600 underline" href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a><br />
+          Website: <a className="text-blue-600 underline" href="https://www.inboxathletics.com">www.inboxathletics.com</a>
+        </p>
+        <p>For security-related concerns: <a className="text-blue-600 underline" href="mailto:security@inboxathletics.com">security@inboxathletics.com</a></p>
+      </div>
+    </main>
+  )
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -43,7 +43,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.6,
     },
     {
-      url: `${baseUrl}/#waitlist`,
+      url: `${baseUrl}/#cta`,
       lastModified: new Date(),
       changeFrequency: "weekly",
       priority: 0.9,

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,83 +1,217 @@
+import Link from "next/link"
+
 export default function TermsPage() {
-    return (
-        <main className="container mx-auto px-4 py-12 max-w-3xl">
-            <h1 className="text-4xl font-bold mb-8">Terms of Service</h1>
-            <div className="prose prose-blue max-w-none">
-                <h2 className="text-xl font-semibold mt-6">1. Eligibility</h2>
-                <ul className="list-disc list-inside">
-                    <li>You must be at least 13 years old to use Inbox Athletics. If you are under 18, you must have
-                        permission from a parent or legal guardian.
-                    </li>
-                    <li>By using the Service, you represent and warrant that you meet all eligibility requirements.</li>
-                </ul>
+  return (
+    <main className="container mx-auto px-4 py-12 max-w-3xl">
+      <Link href="/" className="inline-block mb-8">
+        <img src="/inbox-athletics-logo-without-tagline.svg" alt="Inbox Athletics" className="h-8 w-auto" />
+      </Link>
+      <h1 className="text-4xl font-bold mb-2">Terms of Service</h1>
+      <p className="mb-8">
+        <strong>Inbox Athletics LLC</strong> (&ldquo;Inbox Athletics,&rdquo; &ldquo;we,&rdquo; &ldquo;us,&rdquo; or &ldquo;our&rdquo;) provides a recruiting communication platform for high school student-athletes. By creating an account or using the Inbox Athletics platform (the &ldquo;Service&rdquo;), you agree to these Terms of Service (&ldquo;Terms&rdquo;). Please read them carefully.
+      </p>
+      <p className="mb-8"><strong>Effective Date:</strong> February 18, 2026</p>
+      <div className="prose prose-blue max-w-none">
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">2. Use of the Service</h2>
-                <ul className="list-disc list-inside">
-                    <li>You agree to use the Service only for its intended purposes.</li>
-                    <li>You may not:
-                        <ul className="list-disc list-inside ml-6">
-                            <li>Misrepresent your identity or affiliations.</li>
-                            <li>Upload or transmit unlawful, offensive, or harmful content.</li>
-                            <li>Interfere with or disrupt the Service or its infrastructure.</li>
-                        </ul>
-                    </li>
-                </ul>
+        <h2 className="text-xl font-semibold mt-6">1. Eligibility</h2>
+        <ul className="list-disc list-inside">
+          <li>You must be at least 13 years old to use Inbox Athletics.</li>
+          <li>If you are under 18, your parent or legal guardian must be notified of your account creation. By signing up, you represent that you have provided an accurate parent or guardian email address so that we may send the required parental notification.</li>
+          <li>By using the Service, you represent and warrant that you meet all eligibility requirements and that the information you provide at signup is accurate.</li>
+          <li>Parents or guardians may contact us at <a className="text-blue-600 underline" href="mailto:privacy@inboxathletics.com">privacy@inboxathletics.com</a> to review, modify, or request deletion of a minor&apos;s account and data at any time.</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">3. Accounts and Security</h2>
-                <ul className="list-disc list-inside">
-                    <li>You are responsible for maintaining the confidentiality of your account credentials.</li>
-                    <li>You agree to notify us immediately of any unauthorized use or suspected breach.</li>
-                </ul>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">4. Subscription and Payment</h2>
-                <ul className="list-disc list-inside">
-                    <li>Some features may require a paid subscription. Fees and billing terms will be presented at the
-                        time of purchase.
-                    </li>
-                    <li>All payments are non-refundable unless stated otherwise.</li>
-                </ul>
+        <h2 className="text-xl font-semibold mt-6">2. Accounts and Security</h2>
+        <ul className="list-disc list-inside">
+          <li>You are responsible for maintaining the confidentiality of your account credentials. Do not share your password with anyone.</li>
+          <li>You agree to notify us immediately at <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a> if you suspect any unauthorized access to your account.</li>
+          <li>You are responsible for all activity that occurs under your account.</li>
+          <li>You may not create an account on behalf of another person without their authorization, or create multiple accounts to circumvent platform limitations.</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">5. Communications</h2>
-                <ul className="list-disc list-inside">
-                    <li>By signing up, you agree to receive essential notifications and service-related
-                        communications.
-                    </li>
-                    <li>With your consent, we may send promotional messages. You can opt out at any time.</li>
-                </ul>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">6. User Content</h2>
-                <ul className="list-disc list-inside">
-                    <li>You retain ownership of the content you upload but grant us a license to use, store, and process
-                        it solely to provide and improve the Service.
-                    </li>
-                    <li>We reserve the right to remove content that violates these Terms.</li>
-                </ul>
+        <h2 className="text-xl font-semibold mt-6">3. Use of the Service</h2>
+        <p>You agree to use the Service only for its intended purpose: managing and improving your recruiting communications with college coaches.</p>
+        <p><strong>You may not use the Service to:</strong></p>
+        <ul className="list-disc list-inside">
+          <li>Misrepresent your identity, athletic credentials, academic record, or affiliations to coaches or any other party</li>
+          <li>Send unsolicited bulk or spam messages to college coaches or coaching staff</li>
+          <li>Impersonate a coach, athletic department staff member, or any other person</li>
+          <li>Upload, transmit, or generate content that is unlawful, harassing, defamatory, or obscene</li>
+          <li>Use AI-assisted features to fabricate athletic statistics, honors, or eligibility information</li>
+          <li>Circumvent, disable, or interfere with the security or functionality of the Service</li>
+          <li>Scrape, copy, or systematically extract data from the platform</li>
+          <li>Use the Service for any commercial purpose unrelated to your own recruiting process</li>
+        </ul>
+        <p>Violations of these restrictions may result in immediate account suspension or termination.</p>
 
-                <h2 className="text-xl font-semibold mt-6">7. Intellectual Property</h2>
-                <p>All materials provided by Inbox Athletics, including branding, design, and code, are our intellectual
-                    property and may not be copied or reused without permission.</p>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">8. Termination</h2>
-                <p>We reserve the right to suspend or terminate your account if you violate these Terms or if we deem
-                    your use harmful to the Service.</p>
+        <h2 className="text-xl font-semibold mt-6">4. Google Account Integration</h2>
+        <p>If you connect your Google account to Inbox Athletics, you authorize us to access your Gmail data as described in our <a className="text-blue-600 underline" href="/privacy">Privacy Policy</a> and consistent with the permissions you grant through Google&apos;s OAuth authorization flow.</p>
+        <ul className="list-disc list-inside">
+          <li>You may revoke Google account access at any time through your Inbox Athletics account settings or directly through your <a className="text-blue-600 underline" href="https://myaccount.google.com/permissions">Google Account permissions page</a>.</li>
+          <li>You represent that you are authorized to connect the Google account you link to Inbox Athletics.</li>
+          <li>We will use your Google account data solely as described in our Privacy Policy. We do not use Gmail data for advertising or any purpose unrelated to providing the Service.</li>
+          <li>Revoking Google account access does not delete your Inbox Athletics account. See Section 10 for account deletion.</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">9. Disclaimers and Limitation of Liability</h2>
-                <p>The Service is provided "as is" and "as available." We do not guarantee outcomes from using the
-                    platform (e.g., recruitment success). To the maximum extent permitted by law, we are not liable for
-                    any damages resulting from your use of the Service.</p>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">10. Governing Law</h2>
-                <p>These Terms are governed by the laws of the State of New Jersey, without regard to its conflict of
-                    law principles.</p>
+        <h2 className="text-xl font-semibold mt-6">5. AI-Assisted Features</h2>
+        <p>Inbox Athletics provides AI-powered tools to help you draft emails, analyze your recruiting relationships, and manage communications. By using these features, you acknowledge and agree that:</p>
+        <ul className="list-disc list-inside">
+          <li><strong>You are responsible for all content sent in your name.</strong> AI-generated suggestions are drafts only. You must review and approve any message before sending it to a coach.</li>
+          <li>AI-generated content may contain errors, inaccuracies, or language that is not appropriate for your specific situation. We do not guarantee the quality, accuracy, or effectiveness of any AI-generated content.</li>
+          <li>Using AI-assisted drafting does not transfer responsibility for the content of your communications to Inbox Athletics.</li>
+          <li>To provide AI features, we share relevant message data with third-party AI providers (Anthropic and Google). This is described in detail in our <a className="text-blue-600 underline" href="/privacy">Privacy Policy</a>.</li>
+        </ul>
 
-                <h2 className="text-xl font-semibold mt-6">11. Changes to Terms</h2>
-                <p>We may update these Terms from time to time. We will notify you of any material changes.</p>
+        <hr />
 
-                <h2 className="text-xl font-semibold mt-6">12. Contact</h2>
-                <p>If you have questions about these Terms, contact us at: <a className="text-blue-600 underline"
-                                                                              href="mailto:support@inboxathletics.com">support@inboxathletics.com</a>
-                </p>
-            </div>
-        </main>
-    )
+        <h2 className="text-xl font-semibold mt-6">6. NCAA, NAIA, and Recruiting Compliance</h2>
+        <p>Inbox Athletics is a communication management tool. We do not provide legal, compliance, or eligibility advice.</p>
+        <p><strong>You are solely responsible for ensuring that your use of the platform complies with all applicable rules and regulations</strong>, including those of the NCAA, NAIA, NJCAA, or any other governing body that oversees your recruiting process. This includes rules governing permissible contact with coaches, communication timing, and the use of third-party services in the recruiting process.</p>
+        <p>Inbox Athletics makes no representation that use of the platform is compliant with any particular governing body&apos;s rules. If you have compliance questions, consult your high school athletic director or a qualified compliance advisor.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">7. Coach and Contact Data</h2>
+        <p>The coach contact records in your Inbox Athletics account are created and managed by you. Inbox Athletics does not verify, guarantee, or warrant the accuracy of any coach contact information you enter or import.</p>
+        <p>You are responsible for ensuring that the contact information you add is accurate and that your use of that information complies with applicable law. We are not liable for communications sent to incorrect or outdated contact information.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">8. User Content</h2>
+        <p>You retain ownership of the content you create within Inbox Athletics, including coach notes, profile information, and manually written messages (&ldquo;User Content&rdquo;).</p>
+        <p>By using the Service, you grant Inbox Athletics LLC a limited, non-exclusive license to store, process, and display your User Content solely as necessary to provide the Service to you.</p>
+        <p><strong>We do not use your User Content — including your email communications or AI-generated drafts — to train AI models, build advertising profiles, or for any purpose beyond operating the Service.</strong> This license terminates when you delete your account, subject to our data retention practices described in our Privacy Policy.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">9. Subscriptions and Payment</h2>
+
+        <h3 className="text-lg font-semibold mt-4">Plans</h3>
+        <p>Inbox Athletics offers the following paid subscription plans:</p>
+        <ul className="list-disc list-inside">
+          <li><strong>Monthly:</strong> Billed once per month</li>
+          <li><strong>Annual:</strong> Billed once per year at a discounted rate</li>
+        </ul>
+        <p>Specific pricing is presented at the time of purchase and may be updated with notice as described in Section 14.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Billing</h3>
+        <p>Subscriptions are billed in advance on a recurring basis. By subscribing, you authorize Inbox Athletics to charge your payment method on each renewal date until you cancel. Payments are processed by Stripe. You agree to Stripe&apos;s terms of service in connection with payment processing.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Cancellation</h3>
+        <p>You may cancel your subscription at any time through your account settings or via the billing portal. Cancellation takes effect at the end of your current billing period — you will retain access to paid features through the end of the period you have already paid for. We do not issue partial-period refunds upon cancellation.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Refunds</h3>
+        <p>All subscription fees are non-refundable except as follows: if you request a refund within <strong>7 days of your initial subscription purchase</strong>, we will issue a full refund upon request. To request a refund, contact <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a> within 7 days of your initial charge. Refund requests outside this window are evaluated on a case-by-case basis at our discretion. This refund policy applies to initial purchases only and does not apply to renewal charges.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Free Tier</h3>
+        <p>We may offer a free tier with limited functionality. Free tier access does not require payment and may be modified or discontinued at any time with reasonable notice.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">10. Termination and Account Deletion</h2>
+
+        <h3 className="text-lg font-semibold mt-4">Termination by You</h3>
+        <p>You may delete your account at any time through your account settings. Upon deletion, we will remove your personal data within 30 days in accordance with our Privacy Policy.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Termination by Inbox Athletics</h3>
+        <p>We reserve the right to suspend or terminate your account if you:</p>
+        <ul className="list-disc list-inside">
+          <li>Violate these Terms</li>
+          <li>Use the Service in a way that harms other users, coaches, or the platform</li>
+          <li>Engage in fraudulent, abusive, or illegal activity</li>
+        </ul>
+        <p>For non-urgent violations, we will attempt to provide notice and an opportunity to remedy the issue before termination. For serious violations (e.g., fraud, abuse, security threats), we may terminate immediately without notice.</p>
+        <p>Upon termination for cause, you forfeit any remaining subscription period and are not entitled to a refund.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Effect of Termination</h3>
+        <p>Upon account deletion or termination, your right to access the Service ends. You may request an export of your coach contacts and notes before deletion by contacting <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a>.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">11. Intellectual Property</h2>
+        <p>All materials provided by Inbox Athletics — including the platform design, branding, code, and proprietary features — are the intellectual property of Inbox Athletics LLC and are protected by applicable intellectual property laws. You may not copy, reproduce, modify, or distribute any Inbox Athletics materials without our prior written permission.</p>
+        <p>Nothing in these Terms transfers any intellectual property rights to you beyond the limited right to use the Service as described herein.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">12. Disclaimers</h2>
+        <p>The Service is provided &ldquo;as is&rdquo; and &ldquo;as available&rdquo; without warranties of any kind, express or implied. We do not warrant that:</p>
+        <ul className="list-disc list-inside">
+          <li>The Service will be uninterrupted, error-free, or secure</li>
+          <li>AI-generated content will be accurate, appropriate, or effective</li>
+          <li>Use of the platform will result in recruiting success, scholarship offers, or any particular outcome</li>
+          <li>Coach contact data will be accurate or up to date</li>
+        </ul>
+        <p>We are not responsible for the actions of college coaches, athletic programs, or third-party services you interact with through or in connection with the platform.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">13. Limitation of Liability</h2>
+        <p>To the maximum extent permitted by applicable law, Inbox Athletics LLC, its founders, employees, and affiliates shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of — or inability to use — the Service, including but not limited to lost recruiting opportunities, reputational harm, or NCAA compliance violations.</p>
+        <p>Our total liability to you for any claim arising from these Terms or your use of the Service shall not exceed the greater of (a) the amount you paid to Inbox Athletics in the 12 months preceding the claim, or (b) $100.</p>
+        <p>Some jurisdictions do not allow the exclusion of certain warranties or limitations on liability. In those jurisdictions, our liability is limited to the maximum extent permitted by law.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">14. Dispute Resolution</h2>
+
+        <h3 className="text-lg font-semibold mt-4">Accounts Involving Minors</h3>
+        <p>Because Inbox Athletics is primarily used by student-athletes under the age of 18, we recognize that a parent or legal guardian is typically the responsible party in any dispute. By providing parental notification consent at the time of account creation — or by permitting or facilitating a minor&apos;s use of the Service — a parent or legal guardian agrees to be bound by this Section 14 on behalf of themselves and their minor child.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Informal Resolution First</h3>
+        <p>Before initiating any formal proceeding, the user (or parent/guardian on behalf of a minor user) agrees to contact us at <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a> and allow 30 days to attempt to resolve the dispute informally. We take user concerns seriously and believe most issues can be resolved without formal proceedings.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Binding Arbitration</h3>
+        <p>If a dispute cannot be resolved informally, the parent or guardian (on behalf of themselves and any minor user) and Inbox Athletics LLC agree to resolve it through binding individual arbitration administered by the American Arbitration Association (AAA) under its Consumer Arbitration Rules, rather than in court. The arbitration will be conducted in New Jersey or by videoconference at either party&apos;s election.</p>
+        <p>For users who are 18 or older, this arbitration agreement binds the user directly.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Class Action Waiver</h3>
+        <p><strong>All disputes must be resolved on an individual basis. Neither you nor your minor child may participate in a class action lawsuit or class-wide arbitration against Inbox Athletics. This waiver is agreed to by the parent or guardian on behalf of themselves and their minor child at the time of account creation.</strong></p>
+
+        <h3 className="text-lg font-semibold mt-4">Exceptions</h3>
+        <p>Either party may seek injunctive or other equitable relief in a court of competent jurisdiction to prevent irreparable harm, including unauthorized use of intellectual property or platform security threats. Claims within the jurisdiction of small claims court may also be brought there without first proceeding to arbitration.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Right to Opt Out</h3>
+        <p>If you do not wish to be bound by arbitration, you may opt out by sending written notice to <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a> within 30 days of first creating an account. Opting out does not affect any other provision of these Terms.</p>
+
+        <h3 className="text-lg font-semibold mt-4">Governing Law</h3>
+        <p>These Terms are governed by the laws of the State of New Jersey, without regard to conflict of law principles.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">15. Changes to These Terms</h2>
+        <p>We may update these Terms from time to time. When we make material changes, we will notify you by email and/or a prominent notice within the platform at least <strong>14 days before</strong> the changes take effect. Your continued use of the Service after the effective date constitutes your acceptance of the updated Terms.</p>
+        <p>If you do not agree to the updated Terms, you may cancel your account before the changes take effect.</p>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">16. Miscellaneous</h2>
+        <ul className="list-disc list-inside">
+          <li><strong>Entire Agreement:</strong> These Terms, together with our Privacy Policy, constitute the entire agreement between you and Inbox Athletics LLC regarding the Service.</li>
+          <li><strong>Severability:</strong> If any provision of these Terms is found to be unenforceable, the remaining provisions will continue in full force and effect.</li>
+          <li><strong>No Waiver:</strong> Our failure to enforce any provision of these Terms does not constitute a waiver of our right to enforce it in the future.</li>
+          <li><strong>Assignment:</strong> You may not assign your rights under these Terms without our written consent. We may assign our rights in connection with a merger, acquisition, or sale of assets.</li>
+        </ul>
+
+        <hr />
+
+        <h2 className="text-xl font-semibold mt-6">17. Contact</h2>
+        <p>For questions about these Terms:</p>
+        <p>
+          <strong>Inbox Athletics LLC</strong><br />
+          Email: <a className="text-blue-600 underline" href="mailto:support@inboxathletics.com">support@inboxathletics.com</a><br />
+          Website: <a className="text-blue-600 underline" href="https://www.inboxathletics.com">www.inboxathletics.com</a>
+        </p>
+      </div>
+    </main>
+  )
 }

--- a/components/sections/final-cta.tsx
+++ b/components/sections/final-cta.tsx
@@ -2,7 +2,7 @@ import { WaitlistForm } from "@/components/waitlist-form"
 
 export function FinalCTA() {
   return (
-    <section id="waitlist" className="w-full py-16 md:py-24 bg-brand-600">
+    <section id="cta" className="w-full py-16 md:py-24 bg-brand-600">
       <div className="container px-4 md:px-6">
         <div className="grid gap-8 lg:grid-cols-2 lg:gap-12 items-center">
           <div className="flex flex-col justify-center space-y-6">
@@ -16,9 +16,9 @@ export function FinalCTA() {
           <div className="flex items-center justify-center">
             <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl space-y-4">
               <div>
-                <h3 className="text-xl font-bold text-text-primary">Get Early Access</h3>
+                <h3 className="text-xl font-bold text-text-primary">Stay in the loop</h3>
                 <p className="text-sm text-text-secondary mt-1">
-                  Enter your email and we&apos;ll send you an invite.
+                  Get recruiting tips and early updates.
                 </p>
               </div>
               <WaitlistForm />

--- a/components/sections/header.tsx
+++ b/components/sections/header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link"
 import { useState } from "react"
 import { Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { TrackedCTA } from "@/components/tracked-cta"
 import {
   Sheet,
   SheetContent,
@@ -60,11 +61,17 @@ export function Header() {
               </Link>
             )
           )}
-          <Button className="bg-brand-600 hover:bg-brand-700 text-white">
-            <Link href="#waitlist" onClick={(e) => handleNavClick(e, "waitlist")}>
-              Get Early Access
-            </Link>
-          </Button>
+          <TrackedCTA
+            label="header_sign_in"
+            className="text-sm font-medium text-text-primary hover:text-brand-600 transition-colors"
+          >
+            Sign In
+          </TrackedCTA>
+          <TrackedCTA label="header_get_started">
+            <Button className="bg-brand-600 hover:bg-brand-700 text-white">
+              Get Started
+            </Button>
+          </TrackedCTA>
         </nav>
 
         <Sheet open={open} onOpenChange={setOpen}>
@@ -97,11 +104,17 @@ export function Header() {
                   </Link>
                 )
               )}
-              <Button className="bg-brand-600 hover:bg-brand-700 text-white w-full">
-                <Link href="#waitlist" onClick={(e) => handleNavClick(e, "waitlist")}>
-                  Get Early Access
-                </Link>
-              </Button>
+              <TrackedCTA
+                label="mobile_sign_in"
+                className="text-base font-medium text-text-primary hover:text-brand-600 transition-colors"
+              >
+                Sign In
+              </TrackedCTA>
+              <TrackedCTA label="mobile_get_started">
+                <Button className="bg-brand-600 hover:bg-brand-700 text-white w-full">
+                  Get Started
+                </Button>
+              </TrackedCTA>
             </nav>
           </SheetContent>
         </Sheet>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link"
 import { ArrowRight } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { TrackedCTA } from "@/components/tracked-cta"
 import { smoothScrollTo } from "@/lib/utils"
 
 export function Hero() {
@@ -28,11 +29,11 @@ export function Hero() {
             Inbox Athletics organizes your coach conversations, reminds you to follow up, and helps you communicate like a pro.
           </p>
           <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-            <Button size="lg" className="bg-brand-600 hover:bg-brand-700 text-white">
-              <Link href="#waitlist" onClick={(e) => handleClick(e, "waitlist")} className="flex items-center">
-                Get Early Access
-              </Link>
-            </Button>
+            <TrackedCTA label="hero_get_started">
+              <Button size="lg" className="bg-brand-600 hover:bg-brand-700 text-white">
+                Get Started
+              </Button>
+            </TrackedCTA>
             <Button size="lg" variant="outline" className="border-brand-600 text-brand-600 hover:bg-brand-50">
               <Link href="#how-it-works" onClick={(e) => handleClick(e, "how-it-works")} className="flex items-center">
                 See How It Works <ArrowRight className="ml-2 h-4 w-4" />

--- a/components/sections/pricing.tsx
+++ b/components/sections/pricing.tsx
@@ -1,9 +1,6 @@
-"use client"
-
-import Link from "next/link"
 import { Check } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import { smoothScrollTo } from "@/lib/utils"
+import { TrackedCTA } from "@/components/tracked-cta"
 
 const features = [
   "Email Sync & Organization",
@@ -32,11 +29,6 @@ const plans = [
 ]
 
 export function Pricing() {
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
-    e.preventDefault()
-    smoothScrollTo("waitlist")
-  }
-
   return (
     <section id="pricing" className="w-full py-16 md:py-24 bg-surface">
       <div className="container px-4 md:px-6">
@@ -71,15 +63,15 @@ export function Pricing() {
                   </li>
                 ))}
               </ul>
-              <Button size="lg" className={`w-full ${
-                plan.highlighted
-                  ? "bg-brand-600 hover:bg-brand-700 text-white"
-                  : "bg-white border border-brand-600 text-brand-600 hover:bg-brand-50"
-              }`}>
-                <Link href="#waitlist" onClick={handleClick}>
-                  Get Early Access
-                </Link>
-              </Button>
+              <TrackedCTA label={`pricing_get_started_${plan.name.toLowerCase()}`} className="block">
+                <Button size="lg" className={`w-full ${
+                  plan.highlighted
+                    ? "bg-brand-600 hover:bg-brand-700 text-white"
+                    : "bg-white border border-brand-600 text-brand-600 hover:bg-brand-50"
+                }`}>
+                  Get Started
+                </Button>
+              </TrackedCTA>
             </div>
           ))}
         </div>

--- a/components/waitlist-form.tsx
+++ b/components/waitlist-form.tsx
@@ -83,7 +83,7 @@ export function WaitlistForm() {
         className="bg-brand-600 hover:bg-brand-700 text-white shrink-0"
         disabled={isSubmitting}
       >
-        {isSubmitting ? 'Submitting...' : 'Get Early Access'}
+        {isSubmitting ? 'Submitting...' : 'Stay Updated'}
       </Button>
     </form>
   )

--- a/lib/loops.ts
+++ b/lib/loops.ts
@@ -19,14 +19,11 @@ export async function submitToLoops(
   }
 
   try {
+    const formBody = new URLSearchParams({ email: data.email })
+
     const response = await fetch(`${LOOPS_FORM_ENDPOINT}${LOOPS_FORM_ID}`, {
       method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        email: data.email,
-      }),
+      body: formBody,
     })
 
     if (response.ok) {


### PR DESCRIPTION
## Summary

- **Primary CTAs point to app** — "Get Started" buttons in header, hero, and pricing now link to app.inboxathletics.com via TrackedCTA with PostHog event tracking
- **Header navigation** — added "Sign In" link alongside "Get Started" button (desktop and mobile)
- **Final CTA reframed** — email form repositioned as "Stay in the loop" for users not ready to sign up; keeps original two-column layout
- **Loops CORS fix** — switched form submission from JSON to URLSearchParams to avoid CORS preflight errors
- **Terms of Service** — full legal content covering eligibility, Google integration, AI features, NCAA compliance, subscriptions, dispute resolution, and more
- **Privacy Policy** — full legal content covering data collection, Google API Limited Use disclosure, AI data processing (Anthropic/Google), data retention, children's privacy, and CCPA rights
- **Legal page styling** — added logo linking to home page, consistent hr spacing

## Test plan

- [ ] Verify "Get Started" buttons in header, hero, and pricing link to app.inboxathletics.com
- [ ] Verify "Sign In" link appears in both desktop and mobile nav
- [ ] Submit email form in final CTA section — confirm no CORS error
- [ ] Review Terms of Service page renders all 17 sections correctly
- [ ] Review Privacy Policy page renders all 14 sections with OAuth scope table
- [ ] Verify logo on legal pages links back to home page
- [ ] Check mobile responsive layout on all updated sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)