### PR TITLE
Migrate hosting from GitHub Pages to Cloudflare Workers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-Marketing and waitlist site for Inbox Athletics. Static Next.js site deployed to Cloudflare Pages (project: `inbox-athletics-marketing`). Cloudflare watches `main` and auto-deploys on push; PRs get preview deployments. A GitHub Actions PR check runs type-check + build independently.
+Marketing and waitlist site for Inbox Athletics. Static Next.js site deployed to Cloudflare Workers via Workers Builds (project: `inbox-athletics-marketing`). Cloudflare watches `main` and auto-deploys on push; PRs get preview deployments. A GitHub Actions PR check runs type-check + build independently.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Marketing and waitlist site for [Inbox Athletics](https://www.inboxathletics.com
 - **Forms:** react-hook-form + Zod validation
 - **Waitlist:** Loops.so
 - **Analytics:** PostHog
-- **Hosting:** Cloudflare Pages
+- **Hosting:** Cloudflare Workers (Workers Builds)
 
 ## Getting Started
 
@@ -52,10 +52,11 @@ public/
 
 ## Deployment
 
-Hosted on [Cloudflare Pages](https://pages.cloudflare.com/) (project: `inbox-athletics-marketing`). Cloudflare watches this repo and deploys on every push to `main`; pull requests get automatic preview deployments. Build settings are managed in the Cloudflare Pages dashboard:
+Hosted on [Cloudflare Workers](https://workers.cloudflare.com/) via [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/) (project: `inbox-athletics-marketing`). Cloudflare watches this repo and deploys on every push to `main`; pull requests get automatic preview deployments. Build settings are managed in the Cloudflare dashboard and in `wrangler.jsonc`:
 
 - **Build command:** `pnpm build`
-- **Build output:** `out`
-- **Environment variables:** configured in the Pages project settings (see table above)
+- **Deploy command:** `pnpm dlx wrangler deploy`
+- **Static assets:** `./out` (see `wrangler.jsonc`)
+- **Environment variables:** configured in the Worker project settings (see table above)
 
 Pull requests also run a GitHub Actions check (`.github/workflows/pull-request-check.yml`) that type-checks and builds the site independently of the Cloudflare preview.

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,8 +2,14 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "inbox-athletics-marketing",
   "compatibility_date": "2025-04-01",
+  "workers_dev": false,
+  "preview_urls": true,
   "assets": {
     "directory": "./out",
     "not_found_handling": "404-page"
-  }
+  },
+  "routes": [
+    { "pattern": "inboxathletics.com", "custom_domain": true },
+    { "pattern": "www.inboxathletics.com", "custom_domain": true }
+  ]
 }


### PR DESCRIPTION
## Summary
- Replace the GitHub Pages deploy workflow with a Cloudflare Workers Static Assets config (`wrangler.jsonc`); Cloudflare watches `main` and auto-deploys on push, with preview URLs for PRs
- Retain a GitHub Actions PR check that type-checks and builds the site independently
- Configure `inboxathletics.com` and `www.inboxathletics.com` as Worker custom domains; disable the `workers.dev` route while keeping preview URLs enabled

Motivated by Google OAuth verification repeatedly reporting the GitHub Pages-hosted homepage as unavailable.

## Test plan
- [ ] Cloudflare preview deployment succeeds on this PR
- [ ] GitHub Actions PR check (type-check + build) passes
- [ ] After merge, `https://inboxathletics.com` and `https://www.inboxathletics.com` both serve the site over HTTPS
- [ ] Waitlist form submission still works in production
- [ ] PostHog events still fire on production CTAs

🤖 Generated with [Claude Code](https://claude.com/claude-code)